### PR TITLE
fix variable name generation

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -10,8 +10,6 @@ var template =
 module.exports = function(options, watchers, rerun) {
   if( !options.definitions ) return '';
 
-  var used = {};
-
   var definitions;
   try {
     definitions = eval('('+fs.readFileSync(options.definitions,'utf-8')+')');
@@ -30,6 +28,7 @@ module.exports = function(options, watchers, rerun) {
 
   var sql = '', fn = '', params = [], jsparams = [];
   for( var fnname in definitions ) {
+    var used = {};    
     params = [];
     jsparams = [];
 


### PR DESCRIPTION
Currently the variable pool is global to all defined stored procs, 
f1(a,b)
f2(c,d,e), etc....
once the variable name z is reached, the name generation proc returns undefined.
this fix causes to use the a to z pool for every proc