### PR TITLE
fix stdout maxBuffer exceeded error

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ function afterRun() {
     var cmd = 'psql -d '+options.db+' -f '+options.outfile;
     console.log('Updating PostreSQL: '+cmd);
     exec(cmd, // command line argument directly in string
+      {maxBuffer: 1024 * 500},
       function (error, stdout, stderr) {      // one easy function to capture data/errors
         if (error !== null) {
           console.error('psql exec error: ');


### PR DESCRIPTION
Fixes "stdout maxBuffer exceeded" error when generated sql file gets too big
Added a ridiculously high maxBuffer size, I don't think it is worth exposing this as a config variable.